### PR TITLE
Fix rendering of reveal options

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You can configure almost any reveal.js setting using the _config.yml-settings fi
 * reveal_theme_path: The path to the reveal.js-theme (can be changed for custom themes) [reveal.js/css/theme/]
 * reveal_notes_server: Wether to support the speaker notes server [false (only local speaker notes)]
 * reveal_options: Additional reveal.js [options][]
+
 * reveal_dependencies: Additional reveal.js [dependencies][]
 * reveal_path: Path to the reveal.js-installation [reveal.js]
 
@@ -63,6 +64,39 @@ You can also further customize the presentation:
 
 * extra_css: Additional CSS files added after the reveal theme []
 * highlight_style_sheet: CSS theme for highlight.js [reveal.js/lib/css/zenburn.css]
+
+### Specifying reveal options and dependencies
+
+`reveal_options` can be either a list of strings specifying the Javascript options, e.g.:
+
+```yaml
+reveal_options:
+    - 'width: "960px"'
+    - 'height: "720px"'
+```
+
+or, as a convenience, it can be a mapping of options to their values:
+
+```yaml
+reveal_options:
+    width: 960px
+    height: 720px
+```
+
+Note that if a mapping is passed, the values will be inserted into the
+final javascript as quoted strings. If this is unacceptable (for example,
+if you want to pass a boolean parameter that takes `true` or `false`),
+specify a list of strings.
+
+`reveal_dependencies` takes a list of strings representing the javascript
+to specify a dependency [as you would in reveal.js](https://github.com/hakimel/reveal.js/#dependencies),
+for example:
+
+```yaml
+reveal_dependencies:
+    # Speaker notes
+    - "{ src: 'path/to/plugin.js', async: true },"
+```
 
 ## Custom reveal.js-themes
 

--- a/_layouts/reveal.html
+++ b/_layouts/reveal.html
@@ -68,10 +68,15 @@
 				transition: '{{ site.reveal_transition }}', // default/cube/page/concave/zoom/linear/fade/none
 
                 {% if site.reveal_options %}
-                    {% for option in site.reveal_options %}
-                        {{ option[0] }}: "{{ option[1] }}",
-                    {% endfor %}
-
+                    {% if site.reveal_options.first.first %}
+                        // Reveal options generated from mapping
+                        {% for option in site.reveal_options %}
+                            {{ option[0] }}: "{{ option[1] }}",
+                        {% endfor %}
+                    {% else %}
+                        // Reveal options generated from a list of strings
+                        {{ site.reveal_options | append:',' }}
+                    {% endif %}
                 {% endif %}
 
 				// Optional libraries used to extend on reveal.js

--- a/_layouts/reveal.html
+++ b/_layouts/reveal.html
@@ -8,8 +8,7 @@
 
 		<meta name="description" content="A framework for easily creating beautiful presentations using HTML">
 		<meta name="author" content="Hakim El Hattab">
-
-		<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
@@ -69,8 +68,9 @@
 				transition: '{{ site.reveal_transition }}', // default/cube/page/concave/zoom/linear/fade/none
 
                 {% if site.reveal_options %}
-
-                {{ site.reveal_options | append:',' }}
+                    {% for option in site.reveal_options %}
+                        {{ option[0] }}: "{{ option[1] }}",
+                    {% endfor %}
 
                 {% endif %}
 


### PR DESCRIPTION
Maybe I was specifying options to reveal incorrectly, but my intuition was that the options should be a key-value mapping, like so:

```yaml
reveal_options:
    width: 95%
    height: 95%
```

However, if I specify the options like this, it renders incorrectly. This PR fixes this problem, though I suppose the way it was originally intended to work was:

```yaml
reveal_options:
    - "width: '95%'"
    - "height: '95%'"
```

But I'm not familiar enough with the liquid templating language to check whether the type of `reveal_options`. If you want to preserve the old behavior and can explain how I can check whether `reveal_options` is a hash or an array I'd be happy to update my PR.