### PR TITLE
Add support for custom CSS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ You can configure almost any reveal.js setting using the _config.yml-settings fi
 * reveal_dependencies: Additional reveal.js [dependencies][]
 * reveal_path: Path to the reveal.js-installation [reveal.js]
 
+You can also further customize the presentation:
+
+* extra_css: Additional CSS files added after the reveal theme []
+
 ## Custom reveal.js-themes
 
 If you want to use your custom reveal.js-theme, we recommend adding a directory "theme", putting the file(s)

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,9 @@ reveal_transition: default
 # Path to the used theme (defaults to the Reveal.js standard theme path)
 reveal_theme_path: reveal.js/css/theme/ 
 
+# Additional custom CSS paths
+extra_css: 
+
 # Embed Server-side speaker notes?
 reveal_notes_server: false
 

--- a/_layouts/reveal.html
+++ b/_layouts/reveal.html
@@ -16,6 +16,11 @@
 
 		<link rel="stylesheet" href="{{ site.reveal_path }}css/reveal.css">
 		<link rel="stylesheet" href="{{ site.reveal_theme_path }}{{ site.reveal_theme }}" id="theme">
+{% if site.extra_css %}
+    {% for css_file in site.extra_css %}
+        <link rel="stylesheet" href="{{ css_file }}">
+    {% endfor %}
+{% endif %}
 
 		<!-- For syntax highlighting -->
 		<link rel="stylesheet" href="{{ site.reveal_path }}lib/css/zenburn.css">


### PR DESCRIPTION
I have found that I generally needs a few modifications to a standard reveal.js theme. I've been trying to minimize the degree to which I need to modify the dependencies for my presentations (jekyll-revealjs, reveal.js), so having an additional CSS file applied *after* the theme is very helpful.

Let me know if you want any modifications to this - I could see it working a few different ways (including one where you have the option of disabling the reveal theme entirely).