### PR TITLE
ReadMe tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jekyll-reveal.js
 
-A Jekyll-based framework for creating presentations based on Reveal.js and markdown.
+A Jekyll-based framework for creating presentations based on Reveal.js and Markdown.
 
 ## Introduction
 
@@ -24,7 +24,7 @@ After that, add your slides into the `_posts` subdirectory in clean Markdown syn
 
     jekyll build
 
-You can even manage multiple presentations using the power of git. Simply branch from the master branch to create a new presentation:
+You can even manage multiple presentations using the power of Git. Simply branch from the master branch to create a new presentation:
 
     git checkout master
     git branch presentation2
@@ -66,7 +66,7 @@ You can also further customize the presentation:
 
 ### Specifying reveal options and dependencies
 
-`reveal_options` can be either a list of strings specifying the Javascript options, e.g.:
+`reveal_options` can be either a list of strings specifying the JavaScript options, e.g.:
 
 ```yaml
 reveal_options:
@@ -82,9 +82,9 @@ reveal_options:
   height: 720px
 ```
 
-Note that if a mapping is passed, the values will be inserted into the final javascript as quoted strings. If this is unacceptable (for example, if you want to pass a boolean parameter that takes `true` or `false`), specify a list of strings.
+Note that if a mapping is passed, the values will be inserted into the final JavaScript as quoted strings. If this is unacceptable (for example, if you want to pass a boolean parameter that takes `true` or `false`), specify a list of strings.
 
-`reveal_dependencies` takes a list of strings representing the javascript to specify a dependency [as you would in reveal.js](https://github.com/hakimel/reveal.js/#dependencies), for example:
+`reveal_dependencies` takes a list of strings representing the JavaScript to specify a dependency [as you would in reveal.js](https://github.com/hakimel/reveal.js/#dependencies), for example:
 
 ```yaml
 reveal_dependencies:
@@ -100,7 +100,7 @@ Don't mess with the `reveal.js` subdirectory as it is a subrepository and doesn'
 
 ## Markdown extensions and simplification
 
-Reveal.js already includes a markdown interpreter, which we use for jekyll-reveal.js. We have already configured it and included some simplification just for you!
+Reveal.js already includes a Markdown interpreter, which we use for jekyll-reveal.js. We have already configured it and included some simplification just for you!
 
 ### Multiple slides
 

--- a/README.md
+++ b/README.md
@@ -191,5 +191,5 @@ This is only displayed in the speaker notes.
 [example presentation]: http://dploeger.github.io/jekyll-revealjs/example
 [install jekyll]: http://jekyllrb.com/docs/installation/
 [options]: https://github.com/hakimel/reveal.js#configuration
-[depedencies]: https://github.com/hakimel/reveal.js#dependencies
+[dependencies]: https://github.com/hakimel/reveal.js#dependencies
 [posts]: https://jekyllrb.com/docs/posts/#creating-posts

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Clean the Example presentation:
     git rm _posts/*
     mkdir _posts
 
-After that, add your slides into the `_posts` subdirectory in clean Markdown syntax and you're ready to go with building your presentation with Jekyll:
+After that, add your slides into the `_posts` subdirectory in clean Markdown syntax and you're ready to build your presentation with Jekyll:
 
     jekyll build
 
@@ -32,7 +32,7 @@ You can even manage multiple presentations using the power of Git. Simply branch
 
 ## Slide filenames
 
-Because we're using the Jekyll posts-framework to easily gather the slides for the presentation, we're bound to the conventions of Jekyll posts, namely being
+Because we're using Jekyll [posts][] to easily gather the slides for the presentation, we use their filename conventions with the following syntax:
 
     <year>-<month>-<day>-<title>.md
 
@@ -43,7 +43,7 @@ We recommend naming the files like
 
 and so forth.
 
-Jekyll will assume, that each post has been made on the first of january, 2001 (which is of no interest for a presentation). The additional number is for sorting purposes. After that comes a title to identify the specific slide (which is actually only for the presentation author, Jekyll doesn't care about it).
+Jekyll will assume that each post has been made on the first of January, 2001 (which is of no interest for a presentation). The additional number is for sorting purposes. After that comes a title to identify the specific slide (which is actually only for the presentation author, Jekyll doesn't care about it).
 
 ## Configuring the presentation
 
@@ -82,7 +82,7 @@ reveal_options:
   height: 720px
 ```
 
-Note that if a mapping is passed, the values will be inserted into the final JavaScript as quoted strings. If this is unacceptable (for example, if you want to pass a boolean parameter that takes `true` or `false`), specify a list of strings.
+Note that if a mapping is passed, the values will be inserted into the final JavaScript as quoted strings. If this is unacceptable (for example, if you want to pass a Boolean parameter that takes `true` or `false`), specify a list of strings.
 
 `reveal_dependencies` takes a list of strings representing the JavaScript to specify a dependency [as you would in reveal.js](https://github.com/hakimel/reveal.js/#dependencies), for example:
 
@@ -92,15 +92,15 @@ reveal_dependencies:
   - "{ src: 'path/to/plugin.js', async: true },"
 ```
 
-## Custom reveal.js-themes
+## Custom reveal.js themes
 
-If you want to use your custom reveal.js-theme, we recommend adding a directory `theme`, putting the file(s) there and referencing that directory in the configuration `reveal_theme_path`.
+If you want to use your custom reveal.js theme, we recommend adding a directory `theme`, putting the file(s) there and referencing that directory in the configuration `reveal_theme_path`.
 
-Don't mess with the `reveal.js` subdirectory as it is a subrepository and doesn't adhere to your repository's branches.
+Don't mess with the `reveal.js` subdirectory as it is a submodule and doesn't adhere to your repository's branches.
 
 ## Markdown extensions and simplification
 
-Reveal.js already includes a Markdown interpreter, which we use for jekyll-reveal.js. We have already configured it and included some simplification just for you!
+Reveal.js already includes a Markdown interpreter, which we use for **jekyll-reveal.js**. We have already configured it and included some simplification just for you!
 
 ### Multiple slides
 
@@ -136,7 +136,7 @@ And this is a vertical slide below Slide 1
 
 Fragments allow slide elements to come one by one. This is often used in lists to subsequently show fragments of a list during a presentation.
 
-Jekyll-reveal.js simplifies the reveal.js syntax. To specify the current element as a fragment, use `<fragment/>` like this:
+**jekyll-reveal.js** simplifies the reveal.js syntax. To specify the current element as a fragment, use `<fragment/>` like this:
 
 ```markdown
 # Slide
@@ -148,7 +148,7 @@ Jekyll-reveal.js simplifies the reveal.js syntax. To specify the current element
 
 ### Slide backgrounds
 
-To modify the background of the current slide, jekyll-reveal.js simplifies the syntax to `<background>color</background>`:
+To modify the background of the current slide, **jekyll-reveal.js** simplifies the syntax to `<background>color</background>`:
 
 ```markdown
 # Slide
@@ -160,7 +160,7 @@ This slide has a white background
 
 ### Speaker notes
 
-jekyll-reveal.js is configured, so that speaker notes are identified after an introductory "Note:"-tag:
+To include speaker notes, add `Note:` on a separate line and write your notes below:
 
 ```markdown
 # Slide
@@ -179,3 +179,4 @@ This is only displayed in the speaker notes.
 [install jekyll]: http://jekyllrb.com/docs/installation/
 [options]: https://github.com/hakimel/reveal.js#configuration
 [depedencies]: https://github.com/hakimel/reveal.js#dependencies
+[posts]: https://jekyllrb.com/docs/posts/#creating-posts

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Jekyll-based framework for creating presentations based on Reveal.js and markd
 If you like [Reveal.js][] for creating your online presentations, like the site
 management [Jekyll][] gives you and like [Markdown][] because of its easy and clean look, here's an easy way to create a presentation using Jekyll, Markdown and Reveal.js.
 
-See the [example presentation][] created using the contents in this repository and "jekyll build".
+See the [example presentation][] created using the contents in this repository and `jekyll build`.
 
 ## Howto
 
@@ -21,7 +21,7 @@ Clean the Example presentation:
     git rm _posts/*
     mkdir _posts
 
-After that, add your slides into the _posts-subdirectory in clean Markdown syntax and you're ready to go with building your presentation with Jekyll:
+After that, add your slides into the `_posts` subdirectory in clean Markdown syntax and you're ready to go with building your presentation with Jekyll:
 
     jekyll build
 
@@ -48,22 +48,22 @@ Jekyll will assume, that each post has been made on the first of january, 2001 (
 
 ## Configuring the presentation
 
-You can configure almost any reveal.js setting using the _config.yml-settings file in the root directory.
+You can configure almost any reveal.js setting using the `_config.yml` settings file in the root directory.
 
-* title: The title of your presentation (displayed in the browser's title bar)
-* reveal_theme: The reveal.js-theme to use [default.css]
-* reveal_transition: The reveal.js-transition to use [default]
-* reveal_theme_path: The path to the reveal.js-theme (can be changed for custom themes) [reveal.js/css/theme/]
-* reveal_notes_server: Wether to support the speaker notes server [false (only local speaker notes)]
-* reveal_options: Additional reveal.js [options][]
+* `title`: The title of your presentation (displayed in the browser's title bar)
+* `reveal_theme`: The reveal.js-theme to use [default.css]
+* `reveal_transition`: The reveal.js-transition to use [default]
+* `reveal_theme_path`: The path to the reveal.js-theme (can be changed for custom themes) [reveal.js/css/theme/]
+* `reveal_notes_server`: Wether to support the speaker notes server [false (only local speaker notes)]
+* `reveal_options`: Additional reveal.js [options][]
 
-* reveal_dependencies: Additional reveal.js [dependencies][]
-* reveal_path: Path to the reveal.js-installation [reveal.js]
+* `reveal_dependencies`: Additional reveal.js [dependencies][]
+* `reveal_path`: Path to the reveal.js-installation [reveal.js]
 
 You can also further customize the presentation:
 
-* extra_css: Additional CSS files added after the reveal theme []
-* highlight_style_sheet: CSS theme for highlight.js [reveal.js/lib/css/zenburn.css]
+* `extra_css`: Additional CSS files added after the reveal theme []
+* `highlight_style_sheet`: CSS theme for highlight.js [reveal.js/lib/css/zenburn.css]
 
 ### Specifying reveal options and dependencies
 
@@ -100,10 +100,10 @@ reveal_dependencies:
 
 ## Custom reveal.js-themes
 
-If you want to use your custom reveal.js-theme, we recommend adding a directory "theme", putting the file(s)
-there and referencing that directory in the configuration "reveal_theme_path".
+If you want to use your custom reveal.js-theme, we recommend adding a directory `theme`, putting the file(s)
+there and referencing that directory in the configuration `reveal_theme_path`.
 
-Don't mess with the reveal.js subdirectory as it is a subrepository and doesn't adhere to your repository's
+Don't mess with the `reveal.js` subdirectory as it is a subrepository and doesn't adhere to your repository's
 branches.
 
 ## Markdown extensions and simplification

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can configure almost any reveal.js setting using the `_config.yml` settings 
 You can also further customize the presentation:
 
 - `extra_css`: Additional CSS files added after the reveal [theme][]
-- `highlight_style_sheet`: CSS theme for highlight.js [reveal.js/lib/css/zenburn.css]
+- `highlight_style_sheet`: CSS theme for highlight.js [reveal.js/lib/css/zenburn.css](reveal.js/lib/css/zenburn.css)
 
 ### Specifying reveal options and dependencies
 

--- a/README.md
+++ b/README.md
@@ -115,27 +115,31 @@ configured it and included some simplification just for you!
 
 To use multiple slides in one slide file, use a newline, three dashes and another newline like this:
 
-    # Slide 1
-    
-    This is the content of Slide 1
-    
-    ---
-    
-    # Slide 2
-    
-    This is the content of Slide 2
+```markdown
+# Slide 1
+
+This is the content of Slide 1
+
+---
+
+# Slide 2
+
+This is the content of Slide 2
+```
 
 ### Vertical slides
 
 To use vertical slides, do the same, but use two dashes:
 
-    # Slide 1
-    
-    This is the content of Slide 1
-    
-    --
-    
-    And this is a vertical slide below Slide 1
+```markdown
+# Slide 1
+
+This is the content of Slide 1
+
+--
+
+And this is a vertical slide below Slide 1
+```
 
 ### Fragments
 
@@ -145,34 +149,40 @@ fragments of a list during a presentation.
 Jekyll-reveal.js simplifies the reveal.js syntax. To specify the current element as a fragment, use `<fragment/>` like 
 this:
 
-    # Slide
-    
-    * This <fragment/>
-    * will <fragment/>
-    * come one by one <fragment/>
+```markdown
+# Slide
+
+* This <fragment/>
+* will <fragment/>
+* come one by one <fragment/>
+```
 
 ### Slide backgrounds
 
 To modify the background of the current slide, jekyll-reveal.js simplifies the syntax to 
 `<background>color</background>`:
 
-    # Slide
-    
-    <background>white</background>
-    
-    This slide has a white background
+```markdown
+# Slide
+
+<background>white</background>
+
+This slide has a white background
+```
 
 ### Speaker notes
 
 jekyll-reveal.js is configured, so that speaker notes are identified after an introductory "Note:"-tag:
 
-    # Slide
+```markdown
+# Slide
 
-    Some slide content
+Some slide content
 
-    Note:
+Note:
 
-    This is only displayed in the speaker notes.
+This is only displayed in the speaker notes.
+```
 
 [Reveal.js]:      http://lab.hakim.se/reveal-js/#/
 [Jekyll]:         http://jekyllrb.com/

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ A Jekyll-based framework for creating presentations based on Reveal.js and markd
 
 ## Introduction
 
-If you like [Reveal.js][] for creating your online presentations, like the site
-management [Jekyll][] gives you and like [Markdown][] because of its easy and clean look, here's an easy way to create a presentation using Jekyll, Markdown and Reveal.js.
+If you like [Reveal.js][] for creating your online presentations, like the site management [Jekyll][] gives you and like [Markdown][] because of its easy and clean look, here's an easy way to create a presentation using Jekyll, Markdown and Reveal.js.
 
 See the [example presentation][] created using the contents in this repository and `jekyll build`.
 
@@ -50,20 +49,20 @@ Jekyll will assume, that each post has been made on the first of january, 2001 (
 
 You can configure almost any reveal.js setting using the `_config.yml` settings file in the root directory.
 
-* `title`: The title of your presentation (displayed in the browser's title bar)
-* `reveal_theme`: The reveal.js-theme to use [default.css]
-* `reveal_transition`: The reveal.js-transition to use [default]
-* `reveal_theme_path`: The path to the reveal.js-theme (can be changed for custom themes) [reveal.js/css/theme/]
-* `reveal_notes_server`: Wether to support the speaker notes server [false (only local speaker notes)]
-* `reveal_options`: Additional reveal.js [options][]
+- `title`: The title of your presentation (displayed in the browser's title bar)
+- `reveal_theme`: The reveal.js-theme to use [default.css]
+- `reveal_transition`: The reveal.js-transition to use [default]
+- `reveal_theme_path`: The path to the reveal.js-theme (can be changed for custom themes) [reveal.js/css/theme/]
+- `reveal_notes_server`: Wether to support the speaker notes server [false (only local speaker notes)]
+- `reveal_options`: Additional reveal.js [options][]
 
-* `reveal_dependencies`: Additional reveal.js [dependencies][]
-* `reveal_path`: Path to the reveal.js-installation [reveal.js]
+- `reveal_dependencies`: Additional reveal.js [dependencies][]
+- `reveal_path`: Path to the reveal.js-installation [reveal.js]
 
 You can also further customize the presentation:
 
-* `extra_css`: Additional CSS files added after the reveal theme []
-* `highlight_style_sheet`: CSS theme for highlight.js [reveal.js/lib/css/zenburn.css]
+- `extra_css`: Additional CSS files added after the reveal theme []
+- `highlight_style_sheet`: CSS theme for highlight.js [reveal.js/lib/css/zenburn.css]
 
 ### Specifying reveal options and dependencies
 
@@ -71,45 +70,37 @@ You can also further customize the presentation:
 
 ```yaml
 reveal_options:
-    - 'width: "960px"'
-    - 'height: "720px"'
+  - 'width: "960px"'
+  - 'height: "720px"'
 ```
 
 or, as a convenience, it can be a mapping of options to their values:
 
 ```yaml
 reveal_options:
-    width: 960px
-    height: 720px
+  width: 960px
+  height: 720px
 ```
 
-Note that if a mapping is passed, the values will be inserted into the
-final javascript as quoted strings. If this is unacceptable (for example,
-if you want to pass a boolean parameter that takes `true` or `false`),
-specify a list of strings.
+Note that if a mapping is passed, the values will be inserted into the final javascript as quoted strings. If this is unacceptable (for example, if you want to pass a boolean parameter that takes `true` or `false`), specify a list of strings.
 
-`reveal_dependencies` takes a list of strings representing the javascript
-to specify a dependency [as you would in reveal.js](https://github.com/hakimel/reveal.js/#dependencies),
-for example:
+`reveal_dependencies` takes a list of strings representing the javascript to specify a dependency [as you would in reveal.js](https://github.com/hakimel/reveal.js/#dependencies), for example:
 
 ```yaml
 reveal_dependencies:
-    # Speaker notes
-    - "{ src: 'path/to/plugin.js', async: true },"
+  # Speaker notes
+  - "{ src: 'path/to/plugin.js', async: true },"
 ```
 
 ## Custom reveal.js-themes
 
-If you want to use your custom reveal.js-theme, we recommend adding a directory `theme`, putting the file(s)
-there and referencing that directory in the configuration `reveal_theme_path`.
+If you want to use your custom reveal.js-theme, we recommend adding a directory `theme`, putting the file(s) there and referencing that directory in the configuration `reveal_theme_path`.
 
-Don't mess with the `reveal.js` subdirectory as it is a subrepository and doesn't adhere to your repository's
-branches.
+Don't mess with the `reveal.js` subdirectory as it is a subrepository and doesn't adhere to your repository's branches.
 
 ## Markdown extensions and simplification
 
-Reveal.js already includes a markdown interpreter, which we use for jekyll-reveal.js. We have already
-configured it and included some simplification just for you!
+Reveal.js already includes a markdown interpreter, which we use for jekyll-reveal.js. We have already configured it and included some simplification just for you!
 
 ### Multiple slides
 
@@ -143,24 +134,21 @@ And this is a vertical slide below Slide 1
 
 ### Fragments
 
-Fragments allow slide elements to come one by one. This is often used in lists to subsequently show
-fragments of a list during a presentation.
+Fragments allow slide elements to come one by one. This is often used in lists to subsequently show fragments of a list during a presentation.
 
-Jekyll-reveal.js simplifies the reveal.js syntax. To specify the current element as a fragment, use `<fragment/>` like 
-this:
+Jekyll-reveal.js simplifies the reveal.js syntax. To specify the current element as a fragment, use `<fragment/>` like this:
 
 ```markdown
 # Slide
 
-* This <fragment/>
-* will <fragment/>
-* come one by one <fragment/>
+- This <fragment/>
+- will <fragment/>
+- come one by one <fragment/>
 ```
 
 ### Slide backgrounds
 
-To modify the background of the current slide, jekyll-reveal.js simplifies the syntax to 
-`<background>color</background>`:
+To modify the background of the current slide, jekyll-reveal.js simplifies the syntax to `<background>color</background>`:
 
 ```markdown
 # Slide
@@ -184,11 +172,10 @@ Note:
 This is only displayed in the speaker notes.
 ```
 
-[Reveal.js]:      http://lab.hakim.se/reveal-js/#/
-[Jekyll]:         http://jekyllrb.com/
-[Markdown]:       http://daringfireball.net/projects/markdown/ 
+[reveal.js]: http://lab.hakim.se/reveal-js/#/
+[jekyll]: http://jekyllrb.com/
+[markdown]: http://daringfireball.net/projects/markdown/
 [example presentation]: http://dploeger.github.io/jekyll-revealjs/example
-[install Jekyll]: http://jekyllrb.com/docs/installation/  
+[install jekyll]: http://jekyllrb.com/docs/installation/
 [options]: https://github.com/hakimel/reveal.js#configuration
 [depedencies]: https://github.com/hakimel/reveal.js#dependencies
-

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can configure almost any reveal.js setting using the `_config.yml` settings 
 
 You can also further customize the presentation:
 
-- `extra_css`: Additional CSS files added after the reveal theme []
+- `extra_css`: Additional CSS files added after the reveal [theme][]
 - `highlight_style_sheet`: CSS theme for highlight.js [reveal.js/lib/css/zenburn.css]
 
 ### Specifying reveal options and dependencies
@@ -193,3 +193,4 @@ This is only displayed in the speaker notes.
 [options]: https://github.com/hakimel/reveal.js#configuration
 [dependencies]: https://github.com/hakimel/reveal.js#dependencies
 [posts]: https://jekyllrb.com/docs/posts/#creating-posts
+[theme]: https://github.com/hakimel/reveal.js#theming

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 A Jekyll-based framework for creating presentations based on Reveal.js and Markdown.
 
+- [Introduction](#introduction)
+- [Howto](#howto)
+- [Slide filenames](#slide-filenames)
+- [Configuring the presentation](#configuring-the-presentation)
+  - [Specifying reveal options and dependencies](#specifying-reveal-options-and-dependencies)
+- [Custom reveal.js themes](#custom-revealjs-themes)
+- [Markdown extensions and simplification](#markdown-extensions-and-simplification)
+  - [Multiple slides](#multiple-slides)
+  - [Vertical slides](#vertical-slides)
+  - [Fragments](#fragments)
+  - [Slide backgrounds](#slide-backgrounds)
+  - [Speaker notes](#speaker-notes)
+
 ## Introduction
 
 If you like [Reveal.js][] for creating your online presentations, like the site management [Jekyll][] gives you and like [Markdown][] because of its easy and clean look, here's an easy way to create a presentation using Jekyll, Markdown and Reveal.js.


### PR DESCRIPTION
This PR fixes a few broken links, adds a table of contents, uses fenced code blocks for Markdown syntax highlighting and applies inline code spans in several additional places for consistent formatting.

For the rendered result, see https://github.com/infotexture/jekyll-revealjs/tree/feature/readme-tweaks.

_Thanks for creating this project, very useful indeed!_ 🙏 
