### PR TITLE
Configuration updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+# Generated site (transformed by Jekyll)
 _site
+
+# Bundler configuration & artifacts
+.bundle/config
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,12 @@ reveal_dependencies:
 # Reveal.js subdirectory
 reveal_path: reveal.js/
 
+# Exclude directories and/or files from the conversion
+exclude:
+  - Gemfile*
+  - LICENSE
+  - README.md
+
 # Don't change anything below
 markdown: redcarpet
 highlighter: rouge

--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ exclude:
   - README.md
 
 # Don't change anything below
-markdown: redcarpet
+markdown: kramdown
 highlighter: rouge
 markdown_ext: ignoreme
 


### PR DESCRIPTION
This PR tweaks a few settings in the configuration:

- add a `Gemfile` to permit builds on hosts that do not infer dependencies (like [Netlify](https://www.netlify.com))
- exclude unnecessary files from the conversion to keep the generated  `_site` folder clean
- switch Markdown parser for better compatibility with recent Jekyll versions [as run on GitHub Pages](https://pages.github.com/versions)