### PR TITLE
Add list fragment shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ Fragments allow slide elements to come one by one. This is often used in lists t
 - come one by one <fragment/>
 ```
 
+Or, if you find it cleaner, like this:
+
+```markdown
+# Slide
+
+-[+] This
+-[+] will
+-[+] come one by one
+```
+
 ### Slide backgrounds
 
 To modify the background of the current slide, **jekyll-reveal.js** simplifies the syntax to `<background>color</background>`:

--- a/_layouts/reveal.html
+++ b/_layouts/reveal.html
@@ -48,7 +48,7 @@
 				{% for post in site.posts reversed %}
 				<section data-markdown data-separator="^\n---\n$" data-separator-vertical="^\n--\n$" data-notes="^Note:">
 					<script type="text/template">
-						{{ post.content | replace:'<fragment/>','<!-- .element: class="fragment" -->' | replace:'<background>','<!-- .slide: data-background="' | replace:'</background>','" -->' }}
+						{{ post.content | replace:'<fragment/>','<!-- .element: class="fragment" -->' | replace:'<background>','<!-- .slide: data-background="' | replace:'</background>','" -->' | replace:'-[+]','- <!-- .element: class="fragment" -->' }}
 					</script>
 				</section>
 				{% endfor %}

--- a/_posts/0000-01-03-fragments.md
+++ b/_posts/0000-01-03-fragments.md
@@ -5,3 +5,5 @@ It's also possible to do fragments.
 - You can use &lt;fragment/&gt; to step your list items
 - like <fragment/>
 - this <fragment/>
+-[+] or use ‘&dash;[+]’ instead of ‘-’ for your item like this:  
+  &dash;[+] this is a fragment


### PR DESCRIPTION
This is a more controversial change, as it introduces two ways to do fragments. I wasn’t enjoying how messy the `<fragment/>` code looked in each list item, so I introduced `-[+]` as a shorthand to replace `-`. Open to input.