### PR TITLE
Make indented list items render as fragments

### DIFF
--- a/_layouts/reveal.html
+++ b/_layouts/reveal.html
@@ -62,14 +62,13 @@
 								| replace:'<backgroundimageopacity>','<!-- .slide: data-background-opacity="'
 								| replace:'</backgroundimageopacity>','" -->'
 %}{%
-							assign first_char = line
+							assign first_char = line | strip
 								| slice: 0,1
 %}{%
 							if first_char == '+'
 %}{%
 								assign processed_line = processed_line
-									| replace_first: '+',''
-									| prepend: '+ <!-- .element: class="fragment" -->'
+									| replace_first: '+','+ <!-- .element: class="fragment" -->'
 %}{%
 							endif
 							%}{{ processed_line }}{% comment %}Following line break is important{% endcomment %}

--- a/_posts/0000-01-03-fragments.md
+++ b/_posts/0000-01-03-fragments.md
@@ -6,5 +6,6 @@ It's also possible to do fragments.
   `+ This is a fragment`
 + This is a fragment
 + Your fragment may contain the ‘+’ character
+    + You can also indent fragments
 
 <fragment/>You can use &lt;fragment/&gt; to step other content.


### PR DESCRIPTION
This fixes issue #31 where if you indented an item and used the `+` sign
to make it a fragment, it would simply appear when it’s parent item was
shown. I don’t know why I was using `replace_first` and then `prepend`
as it seems simpler to just use `replace_first` as I have now. This
preserves the indent whitespace of the list item and seems to work
properly.