### PR TITLE
Add a mechanism to escape '+' fragments

### DIFF
--- a/_layouts/reveal.html
+++ b/_layouts/reveal.html
@@ -62,13 +62,22 @@
 								| replace:'<backgroundimageopacity>','<!-- .slide: data-background-opacity="'
 								| replace:'</backgroundimageopacity>','" -->'
 %}{%
-							assign first_char = line | strip
+							assign first_char = line
 								| slice: 0,1
+%}{%
+							assign first_two = line
+								| slice: 0,2
 %}{%
 							if first_char == '+'
 %}{%
 								assign processed_line = processed_line
-									| replace_first: '+','+ <!-- .element: class="fragment" -->'
+									| replace_first: '+',''
+									| prepend: '+ <!-- .element: class="fragment" -->'
+%}{%
+							elsif first_two == '\+'
+%}{%
+								assign processed_line = processed_line
+									| replace_first: '\+', '+'
 %}{%
 							endif
 							%}{{ processed_line }}{% comment %}Following line break is important{% endcomment %}

--- a/_posts/0000-01-03-fragments.md
+++ b/_posts/0000-01-03-fragments.md
@@ -9,3 +9,12 @@ It's also possible to do fragments.
     + You can also indent fragments
 
 <fragment/>You can use &lt;fragment/&gt; to step other content.
+
+--
+
+To start a line with a literal `+`, use `\+`:
+
+```diff
+-I am a grate speller
+\+I am a great speller
+```


### PR DESCRIPTION
Prior to this change, it was not possible to start a line with `+` at all, which is particularly problematic when you have a diff in literal blocks.

Possibly a better long-term fix for this problem would be to disable all pre-processing between triple-backticks, but the ability to escape `+` at the beginning of a line seems useful in itself and is much easier to implement.